### PR TITLE
Adds the active class to the last trail element

### DIFF
--- a/src/Resources/contao/templates/mmenu_default.html5
+++ b/src/Resources/contao/templates/mmenu_default.html5
@@ -14,6 +14,13 @@ if ($this->options['drag']['menu']['open']) {
 <script>
     document.addEventListener(
         "DOMContentLoaded", function () {
+            const menu = document.querySelector('#<?= $this->elementId ?>');
+            if (null !== menu && 0 === menu.querySelectorAll('li.submenu.active').length) {
+                const trails = menu.querySelectorAll('li.submenu.trail');
+                if (0 < trails.length) {
+                    trails.item(trails.length - 1).classList.add('active');
+                }
+            }
             new Mmenu('#<?= $this->elementId ?>', <?= json_encode($this->options) ?>, <?= json_encode($this->configuration) ?>);
         }
     );


### PR DESCRIPTION
Adds the active class to the last trail element if no active one was found.
Of course there we could even add a new class to the active item e.g. `selected` and change the configuration here:
https://github.com/dklemmt/contao_dk_mmenu/blob/57e92edc0d0fe26df8b3295bc44e9e27050f6da6/src/Helper/MmenuHelper.php#L42