### PR TITLE
Ignore submenu selector to rearrange active item

### DIFF
--- a/src/Resources/contao/templates/mmenu_default.html5
+++ b/src/Resources/contao/templates/mmenu_default.html5
@@ -15,8 +15,8 @@ if ($this->options['drag']['menu']['open']) {
     document.addEventListener(
         "DOMContentLoaded", function () {
             const menu = document.querySelector('#<?= $this->elementId ?>');
-            if (null !== menu && 0 === menu.querySelectorAll('li.submenu.active').length) {
-                const trails = menu.querySelectorAll('li.submenu.trail');
+            if (null !== menu && 0 === menu.querySelectorAll('li.active').length) {
+                const trails = menu.querySelectorAll('li.trail');
                 if (0 < trails.length) {
                     trails.item(trails.length - 1).classList.add('active');
                 }


### PR DESCRIPTION
Unfortunately, the `.submenu` selector from https://github.com/dklemmt/contao_dk_mmenu/pull/58 is too strict for pages with related reader module, so we need to rearrange the active item without this selector!