### PR TITLE
chore: support doctrine/dbal ^3.3 || ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": ">=7.4",
         "contao/core-bundle": "^4.13 || ^5.0",
-        "doctrine/dbal": "^2.11 || ^3.0",
+        "doctrine/dbal": "^3.3 || ^4.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
         "symfony/finder": "^5.4 || ^6.0 || ^7.0",

--- a/src/Migration/JsTemplateLayoutMigration.php
+++ b/src/Migration/JsTemplateLayoutMigration.php
@@ -29,9 +29,7 @@ final class JsTemplateLayoutMigration extends AbstractMigration
 
     public function shouldRun(): bool
     {
-        $schemaManager = method_exists($this->connection, 'createSchemaManager') ?
-            $this->connection->createSchemaManager() :
-            $this->connection->getSchemaManager();
+        $schemaManager = $this->connection->createSchemaManager();
 
         if (!$schemaManager->tablesExist(['tl_layout'])) {
             return false;
@@ -50,9 +48,7 @@ final class JsTemplateLayoutMigration extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $schemaManager = method_exists($this->connection, 'createSchemaManager') ?
-            $this->connection->createSchemaManager() :
-            $this->connection->getSchemaManager();
+        $schemaManager = $this->connection->createSchemaManager();
 
         if ($schemaManager->tablesExist(['tl_layout'])) {
             $result = $this->connection->executeQuery("SELECT `id`, `scripts` FROM `tl_layout` WHERE `scripts` LIKE '%\"js_mmenu%'")->fetchAllAssociative();

--- a/src/Migration/JsTemplateModuleMigration.php
+++ b/src/Migration/JsTemplateModuleMigration.php
@@ -28,9 +28,7 @@ final class JsTemplateModuleMigration extends AbstractMigration
 
     public function shouldRun(): bool
     {
-        $schemaManager = method_exists($this->connection, 'createSchemaManager') ?
-            $this->connection->createSchemaManager() :
-            $this->connection->getSchemaManager();
+        $schemaManager = $this->connection->createSchemaManager();
 
         if (!$schemaManager->tablesExist(['tl_module'])) {
             return false;
@@ -49,9 +47,7 @@ final class JsTemplateModuleMigration extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $schemaManager = method_exists($this->connection, 'createSchemaManager') ?
-            $this->connection->createSchemaManager() :
-            $this->connection->getSchemaManager();
+        $schemaManager = $this->connection->createSchemaManager();
 
         if ($schemaManager->tablesExist(['tl_module'])) {
             $this->connection->executeStatement(

--- a/src/Migration/MmConfigMigration.php
+++ b/src/Migration/MmConfigMigration.php
@@ -118,62 +118,7 @@ final class MmConfigMigration extends AbstractMigration
                 $config['keyboardNavigation'] = (int) ($module['dk_mmenuKeyboardNavigation'] ?? 0);
                 $config['keyboardNavigationEnhance'] = (int) ($module['dk_mmenuKeyboardNavigationEnhance'] ?? 0);
 
-                $this->connection->executeStatement(
-                    'INSERT INTO tl_dk_mmenu_config (
-                            `title`,
-                            `tstamp`,
-                            `position`,
-                            `zposition`,
-                            `slidingSubmenus`,
-                            `theme`,
-                            `moveBackground`,
-                            `pageDim`,
-                            `fullscreen`,
-                            `countersAdd`,
-                            `columnsAdd`,
-                            `searchfieldAdd`,
-                            `iconPanels`,
-                            `menuEffects`,
-                            `panelEffects`,
-                            `listEffects`,
-                            `shadows`,
-                            `onClickClose`,
-                            `pageSelector`,
-                            `dragOpenEnable`,
-                            `dragOpenMaxStartPos`,
-                            `dragOpenThreshold`,
-                            `polyfillEnable`,
-                            `keyboardNavigation`,
-                            `keyboardNavigationEnhance`
-                        ) VALUES (
-                            :title,
-                            :tstamp,
-                            :position,
-                            :zposition,
-                            :slidingSubmenus,
-                            :theme,
-                            :moveBackground,
-                            :pageDim,
-                            :fullscreen,
-                            :countersAdd,
-                            :columnsAdd,
-                            :searchfieldAdd,
-                            :iconPanels,
-                            :menuEffects,
-                            :panelEffects,
-                            :listEffects,
-                            :shadows,
-                            :onClickClose,
-                            :pageSelector,
-                            :dragOpenEnable,
-                            :dragOpenMaxStartPos,
-                            :dragOpenThreshold,
-                            :polyfillEnable,
-                            :keyboardNavigation,
-                            :keyboardNavigationEnhance
-                        )',
-                    $config,
-                );
+                $this->connection->insert('tl_dk_mmenu_config', $config);
                 $configId = (int) $this->connection->lastInsertId();
 
                 $this->connection->executeStatement(

--- a/src/Migration/MmConfigMigration.php
+++ b/src/Migration/MmConfigMigration.php
@@ -121,10 +121,7 @@ final class MmConfigMigration extends AbstractMigration
                 $this->connection->insert('tl_dk_mmenu_config', $config);
                 $configId = (int) $this->connection->lastInsertId();
 
-                $this->connection->executeStatement(
-                    'UPDATE `tl_module` SET `dk_mmenuConfig` = ? WHERE id = ?',
-                    [$configId, $module['id']],
-                );
+                $this->connection->update('tl_module', ['dk_mmenuConfig' => $configId], ['id' => $module['id']]);
             }
         }
 

--- a/src/Migration/MmConfigMigration.php
+++ b/src/Migration/MmConfigMigration.php
@@ -28,9 +28,7 @@ final class MmConfigMigration extends AbstractMigration
 
     public function shouldRun(): bool
     {
-        $schemaManager = method_exists($this->connection, 'createSchemaManager') ?
-            $this->connection->createSchemaManager() :
-            $this->connection->getSchemaManager();
+        $schemaManager = $this->connection->createSchemaManager();
 
         if ($schemaManager->tablesExist(['tl_dk_mmenu_config'])) {
             return false;
@@ -87,9 +85,7 @@ final class MmConfigMigration extends AbstractMigration
             'ALTER TABLE tl_module ADD dk_mmenuConfig INT UNSIGNED DEFAULT 0 NOT NULL',
         );
 
-        $schemaManager = method_exists($this->connection, 'createSchemaManager') ?
-            $this->connection->createSchemaManager() :
-            $this->connection->getSchemaManager();
+        $schemaManager = $this->connection->createSchemaManager();
 
         if ($schemaManager->tablesExist(['tl_dk_mmenu_config', 'tl_module'])) {
             $result = $this->connection->executeQuery("SELECT * FROM `tl_module` WHERE `type` LIKE 'mmenu%'")->fetchAllAssociative();
@@ -122,7 +118,7 @@ final class MmConfigMigration extends AbstractMigration
                 $config['keyboardNavigation'] = (int) ($module['dk_mmenuKeyboardNavigation'] ?? 0);
                 $config['keyboardNavigationEnhance'] = (int) ($module['dk_mmenuKeyboardNavigationEnhance'] ?? 0);
 
-                $stmt = $this->connection->prepare(
+                $this->connection->executeStatement(
                     'INSERT INTO tl_dk_mmenu_config (
                             `title`,
                             `tstamp`,
@@ -176,8 +172,8 @@ final class MmConfigMigration extends AbstractMigration
                             :keyboardNavigation,
                             :keyboardNavigationEnhance
                         )',
+                    $config,
                 );
-                $stmt->executeQuery($config);
                 $configId = (int) $this->connection->lastInsertId();
 
                 $this->connection->executeStatement(


### PR DESCRIPTION
Drop DBAL 2 support and make the migrations compatible with DBAL 4:

* Bump the constraint to `^3.3 || ^4.0`
* Use `Connection::createSchemaManager()` exclusively
	* `getSchemaManager()` was only needed for DBAL 2 and the method no longer exists in DBAL 4
* Replace `prepare()` + `Statement::executeQuery($params)` with `Connection::executeStatement($sql, $params)` in `MmConfigMigration`
	* DBAL 4 removed the params argument from `Statement::executeQuery()`

Fixes #86 and #88 